### PR TITLE
fix: TSCH-116 Keyboard will crash after input @ symbol in WiFi password input box

### DIFF
--- a/src/main/java/com/yuyan/imemodule/manager/InputModeSwitcherManager.kt
+++ b/src/main/java/com/yuyan/imemodule/manager/InputModeSwitcherManager.kt
@@ -339,9 +339,8 @@ object InputModeSwitcherManager {
             EditorInfo.IME_ACTION_DONE -> enterState = 4
         }
         mToggleStates.mStateEnter = enterState
-        if (newInputMode != mInputMode && MODE_UNSET != newInputMode) {
-            saveInputMode(newInputMode)
-        }
+        saveInputMode(newInputMode)
+
     }
 
     val isNumberSkb: Boolean


### PR DESCRIPTION
[TSCH-116](fix: TSCH-116 Keyboard will crash after input @ symbol in WiFi password input box)

[TSCH-116]: https://ifitdev.atlassian.net/browse/TSCH-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ